### PR TITLE
[pool-1] - Catch worker fails

### DIFF
--- a/examples/simple.go
+++ b/examples/simple.go
@@ -38,6 +38,6 @@ func main() {
 		}
 	}()
 
-	// wait while at least one worker is active
+	// wait while at least one worker is alive
 	pool.Wait()
 }

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,14 @@
-##Go :: Pool of workers
+## Go :: Pool of workers
 Pool of workers that allows to dynamically update the number of active workers.
 
-##Installation
+## Installation
 ```bash
 go get github.com/enriquebris/workerpool
 ```
 
-##Examples
+## Examples
 
-###Simple usage
+### Simple usage
 
 ```go
 package main


### PR DESCRIPTION
1 - Each worker will catch any panic that bubbled up (from the worker user function) and will terminate its execution. The active workers counter will be updated at the same time.

2 - Basic example added